### PR TITLE
Adding nJet20BadFastsim counter

### DIFF
--- a/TTHAnalysis/python/analyzers/treeProducerSusyFullHad.py
+++ b/TTHAnalysis/python/analyzers/treeProducerSusyFullHad.py
@@ -57,6 +57,8 @@ susyFullHad_globalVariables = susyCore_globalVariables + [
     NTupleVariable("nJet30FailId", lambda ev: sum([j.pt() > 30 for j in ev.cleanJetsFailIdAll]), int, help="Number of jets after photon-cleaning with pt > 30, |eta|<4.7"),
     NTupleVariable("nJet100FailId", lambda ev: sum([j.pt() > 100 for j in ev.cleanJetsFailIdAll]), int, help="Number of jets after photon-cleaning with pt > 100, |eta|<4.7"),
 
+    NTupleVariable("nJet20BadFastsim", lambda ev: sum([j.pt() > 20 and (j.mcJet.pt() if getattr(j,"mcJet",None) else 0.)==0. and j.chargedHadronEnergyFraction()<0.1 for j in ev.cleanJets]), int, help="Number of bad (fast-sim) jets with pt > 20, |eta|<2.5 (FASTSIM VETO)"),
+
     NTupleVariable("nBJet40", lambda ev: sum([j.btagWP("CSVv2IVFM") for j in ev.cleanJets if j.pt() > 40]), int, help="Number of jets with pt > 40 passing CSV medium"),
     NTupleVariable("nBJet30", lambda ev: sum([j.btagWP("CSVv2IVFM") for j in ev.cleanJets if j.pt() > 30]), int, help="Number of jets with pt > 25 passing CSV medium"),
     NTupleVariable("nBJet25", lambda ev: sum([j.btagWP("CSVv2IVFM") for j in ev.cleanJets if j.pt() > 25]), int, help="Number of jets with pt > 25 passing CSV medium"),


### PR DESCRIPTION
This counter counts jets with no matched GEN jet, CHF<0.1, pT>20 GeV and |eta|<2.5.
If this counter > 0, then the fast-SIM event should be veto'd.

The counter is added by default to any process: also full-sim and data. 
For the latter, it's simply a counter of events with jets with CHF<0.1, pT>20 GeV and |eta|<2.5.
Indeed, there is not GEN matching by construction.
